### PR TITLE
Bugfix - react-native-contacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^0.14.8",
     "react-native": "^0.24.1",
     "react-native-alphabetlistview": "^0.2.0",
+    "react-native-contacts": "git+ssh://git@github.com/ajwhite/react-native-contacts#null-pointer",
     "react-native-contacts": "^0.2.5",
     "react-native-router-flux": "^3.22.23",
     "react-native-vector-icons": "^1.3.4",


### PR DESCRIPTION
Hit a [crash report](http://crashes.to/s/7bc64015c82) from the dependency [react-native-contacts](https://github.com/rt2zz/react-native-contacts)

PR has been submitted over in https://github.com/rt2zz/react-native-contacts/pull/63. While that is in review, this temporarily points the dependency to the patched branch on my fork.

Small scenario where the `ContentResolver.query` would return `null` and was not being checked
